### PR TITLE
Add v-model support

### DIFF
--- a/dist/vue-filepond.esm.js
+++ b/dist/vue-filepond.esm.js
@@ -134,6 +134,7 @@ export default (...plugins) => {
             // Map FilePond callback methods to Vue $emitters
             const options = events.reduce((obj, value) => {
                 obj[value] = (...args) => {
+                    this.$emit('input', this._pond.getFiles());
                     this.$emit(value.substr(2), ...args);
                 };
                 return obj;


### PR DESCRIPTION
This changes adds v-model support. Whenever an event occurs an `input` event is emitted which is used by v-model to update a property in the parent component.

You can see an example of it working here: https://codesandbox.io/s/21nl720q6n

The `exampleValue` property is reactive and will always reflect the list of files in filepond.

e.g: If uploads where working you would see the `serverId` populate after upload is complete without the need to listen for any additional events or do any extra work.

v-model is a focal point of VueJS and more can be read about it here: https://vuejs.org/v2/guide/forms.html