### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,7 +127,7 @@ export default (...plugins) => {
       const options = events.reduce((obj, value) => {
         obj[value] = (...args) => {
           this.$emit("input", this._pond ? this._pond.getFiles() : []);
-          this.$emit(value.substr(2), ...args);
+          this.$emit(value.slice(2), ...args);
         };
         return obj;
       }, {});


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.