### PR TITLE
Fix missing setOptions export in type file

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,4 +29,4 @@ declare const VueFilePond: (...plugins: any[]) => ComponentOptions<any, VueFileP
 
 export default VueFilePond;
 
-export const setOptions: (options: FilePondOptionProps) => {};
+export const setOptions: (options: FilePondOptionProps) => void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,3 +28,5 @@ export class VueFilePondComponent extends VueConstructor<VueFilePondInstanceMeth
 declare const VueFilePond: (...plugins: any[]) => ComponentOptions<any, VueFilePondInstanceMethods, any, VueFilepondProps>
 
 export default VueFilePond;
+
+export const setOptions: (options: FilePondOptionProps) => {};


### PR DESCRIPTION
The export is missing in the type file

https://github.com/pqina/vue-filepond/blob/master/lib/index.js#L46

This creates typescript errors when trying to use `import { setOptions } from 'vue-filepond'`